### PR TITLE
mfg: Allow verification of embedded images

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/apache/mynewt-artifact/errors"
 	"github.com/otiai10/copy"
@@ -33,6 +34,7 @@ import (
 
 var OptOutFilename string
 var OptInPlace bool
+var OptVerifyImages bool
 var OptSignKeys []string
 var OptEncKeys []string
 var OptManifest string
@@ -106,4 +108,18 @@ func WriteFile(data []byte, filename string) error {
 
 	iutil.Printf("Wrote file \"%s\"\n", filename)
 	return nil
+}
+
+func Indent(s string, spaceCount int) string {
+	return strings.Repeat(" ", spaceCount) + s
+}
+
+func IndentLines(lines []string, spaceCount int) []string {
+	res := make([]string, len(lines))
+
+	for i, line := range lines {
+		res[i] = Indent(line, spaceCount)
+	}
+
+	return res
 }

--- a/cli/verify.go
+++ b/cli/verify.go
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/apache/mynewt-artifact/image"
+	"github.com/apache/mynewt-artifact/manifest"
+	"github.com/apache/mynewt-artifact/mfg"
+	"github.com/apache/mynewt-artifact/sec"
+)
+
+// Each of these functions verifies one aspect of an image or mfgimage.  They
+// return a string containing the result of the check and a bool indicating
+// success / failure.
+
+func verifyImageStructureStr(img image.Image) (string, bool) {
+	prefix := " structure: "
+
+	if err := img.VerifyStructure(); err != nil {
+		return prefix + fmt.Sprintf("BAD (%s)", err.Error()), false
+	}
+
+	return prefix + "good", true
+}
+
+func verifyImageSigsStr(img image.Image, keys []sec.PubSignKey) (string, bool) {
+	prefix := "signatures: "
+
+	sigs, err := img.CollectSigs()
+	if err != nil {
+		return prefix + fmt.Sprintf("BAD (%s)", err.Error()), false
+	}
+
+	if len(sigs) == 0 {
+		return prefix + "n/a", true
+	}
+
+	if len(keys) == 0 {
+		return prefix + "not checked", true
+	}
+
+	idx, err := img.VerifySigs(keys)
+	if err != nil {
+		return prefix + fmt.Sprintf("BAD (%s)", err.Error()), false
+	}
+
+	return prefix + fmt.Sprintf("good (%s)", OptSignKeys[idx]), true
+}
+
+func verifyImageHashStr(img image.Image, keys []sec.PrivEncKey) (string, bool) {
+	prefix := "      hash: "
+	if img.IsEncrypted() && len(keys) == 0 {
+		return prefix + "not checked (image encrypted; no keys specified)", true
+	}
+
+	keyIdx, err := img.VerifyHash(keys)
+	if err != nil {
+		return prefix + fmt.Sprintf("BAD (%s)", err.Error()), false
+	}
+
+	msg := "good"
+	if keyIdx != -1 {
+		msg += fmt.Sprintf(" (%s)", OptEncKeys[keyIdx])
+	}
+	return prefix + msg, true
+}
+
+func verifyImageManifestStr(img image.Image, man *manifest.Manifest) (string, bool) {
+	prefix := "  manifest: "
+
+	if man == nil {
+		return prefix + "n/a", true
+	}
+
+	if err := img.VerifyManifest(*man); err != nil {
+		return prefix + fmt.Sprintf("BAD (%s)", err.Error()), false
+	}
+
+	return prefix + "good", true
+}
+
+func verifyMfgStructureStr(m mfg.Mfg, man manifest.MfgManifest) (string, bool) {
+	prefix := " structure: "
+
+	if err := m.VerifyStructure(man.EraseVal); err != nil {
+		return prefix + fmt.Sprintf("BAD (%s)", err.Error()), false
+	}
+
+	return prefix + "good", true
+}
+
+func verifyMfgSigsStr(m mfg.Mfg, man manifest.MfgManifest, keys []sec.PubSignKey) (string, bool) {
+	prefix := "signatures: "
+
+	if len(man.Signatures) == 0 {
+		return prefix + "n/a", true
+	}
+
+	if len(keys) == 0 {
+		return prefix + "not checked", true
+	}
+
+	idx, err := mfg.VerifySigs(man, keys)
+	if err != nil {
+		return prefix + fmt.Sprintf("BAD (%s)", err.Error()), false
+	}
+
+	return prefix + fmt.Sprintf("good (%s)", OptSignKeys[idx]), true
+}
+
+func verifyMfgManifestStr(m mfg.Mfg, man manifest.MfgManifest) (string, bool) {
+	prefix := "  manifest: "
+
+	if err := m.VerifyManifest(man); err != nil {
+		return prefix + fmt.Sprintf("BAD (%s)", err.Error()), false
+	}
+
+	return prefix + "good", true
+}

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module mynewt.apache.org/imgmod
 
 require (
-	github.com/apache/mynewt-artifact v0.0.3
+	github.com/apache/mynewt-artifact v0.0.9
 	github.com/otiai10/copy v1.0.1
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/apache/mynewt-artifact v0.0.2 h1:2tBlf84kyAifrEilcw1kQFQ8kpq4wBSudXpO
 github.com/apache/mynewt-artifact v0.0.2/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/apache/mynewt-artifact v0.0.3 h1:760wpGruGSOPjslEo0fgs9PYJ58IAvyjuJqno1t4iOc=
 github.com/apache/mynewt-artifact v0.0.3/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
+github.com/apache/mynewt-artifact v0.0.9/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=


### PR DESCRIPTION
The `mfg verify` command now takes a new option: `--images`.  If this option is specified, the command verifies images embedded in the mfgimage.  Keys used during this check are passed via the `--signkey` and `--enckey` options (both may be repeated for multiple keys).