### PR TITLE
Pull in mynewt-artifact v0.0.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module mynewt.apache.org/imgmod
 
 require (
-	github.com/apache/mynewt-artifact v0.0.19
+	github.com/apache/mynewt-artifact v0.0.20
 	github.com/otiai10/copy v1.0.1
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/apache/mynewt-artifact v0.0.18 h1:E5em2q/hbkDU0/xSGJozWdKSo42XJcZVmSL
 github.com/apache/mynewt-artifact v0.0.18/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/apache/mynewt-artifact v0.0.19 h1:g/LjJvl0amG38INCEf1Gl/i0Z8wJl0dgN2elCcL0hIg=
 github.com/apache/mynewt-artifact v0.0.19/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
+github.com/apache/mynewt-artifact v0.0.20 h1:zf3RACAEGNH0s11QyqB8QeAuMr/e/DmRfHaP5pLjzpw=
+github.com/apache/mynewt-artifact v0.0.20/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=


### PR DESCRIPTION
This patch updates the mynewt-artifact to v0.0.20 to pick up additional TLV
support for AES_NONCE, SECRET_ID, and SECTION.

Signed-off-by: Andy Gross <andy.gross@juul.com>